### PR TITLE
增加 财联社-电报接口

### DIFF
--- a/.env
+++ b/.env
@@ -46,3 +46,4 @@ STOCK_API=https://stock.xueqiu.com/v5/stock/hot_stock/list.json?size=30&_type=10
 STOCK_LOGIN_API=https://xueqiu.com/hq
 ZAOBAO_API=https://www.zaochenbao.com
 ZHIHU_API=https://www.zhihu.com/api/v3/feed/topstory/hot-lists/total?limit=20&desktop=true
+CLS_API=https://www.cls.cn

--- a/bin/www.ts
+++ b/bin/www.ts
@@ -27,6 +27,8 @@ const server = http.createServer(app);
 server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);
+console.log(`服务启动成功，端口：${port}`);
+
 
 /**
  * 将端口规范化为数字、字符串或 false。

--- a/constant/index.ts
+++ b/constant/index.ts
@@ -48,3 +48,4 @@ export const STOCK_API = process.env.STOCK_API
 export const STOCK_LOGIN_API = process.env.STOCK_LOGIN_API
 export const ZAOBAO_API = process.env.ZAOBAO_API
 export const ZHIHU_API = process.env.ZHIHU_API
+export const CLS_API = process.env.CLS_API

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "express": "5.0.0",
     "fast-xml-parser": "^5.2.0",
     "http-errors": "~1.6.3",
+    "jssha": "^3.3.1",
     "morgan": "~1.9.1",
     "nodemon": "^3.1.9",
-    "pug": "3.0.3"
+    "pug": "3.0.3",
+    "ts-md5": "^1.3.1"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.8",

--- a/shared/cls.ts
+++ b/shared/cls.ts
@@ -1,0 +1,157 @@
+import axios, { AxiosResponse } from "axios";
+import dayjs from "dayjs/esm";
+import utcPlugin from "dayjs/esm/plugin/utc";
+import timezonePlugin from "dayjs/esm/plugin/timezone";
+dayjs.extend(utcPlugin);
+dayjs.extend(timezonePlugin);
+import jsSHA from "jssha";
+import * as cheerio from "cheerio";
+import { Md5 } from "ts-md5";
+
+import { CLS_API } from "../constant";
+import { Telegram, Params } from "../types/cls";
+
+/**
+ * 获取请求参数的加密字段
+ * @param {Object} params 请求参数
+ * @returns {String} 加密字段sign
+ */
+
+const sign = (params: any) => {
+  let str = "";
+  const sha1 = new jsSHA("SHA-1", "TEXT");
+  for (const key in params) {
+    str += `${key}=${params[key]}&`;
+  }
+  sha1.update(str);
+  const sign = Md5.hashStr(sha1.getHash("HEX"));
+  return sign;
+};
+
+/**
+ * 最新电报列表
+ * @returns {Promise<TelegramRes>} 新闻列表
+ */
+const refreshTelegraphList = async () => {
+  const params: {
+    app: string;
+    lastTime: number;
+    os: string;
+    sv: string;
+    sign?: string;
+  } = {
+    app: "CailianpressWeb",
+    os: "web",
+    sv: "8.4.6",
+    lastTime: dayjs().unix(), // 前5分钟的时间戳
+  };
+  try {
+    params.sign = sign(params);
+    const url = `${CLS_API}/nodeapi/refreshTelegraphList`;
+    const {
+      a: lastTime,
+      i: firstTime,
+      l: list,
+    } = (await axios.get(url, { params })).data;
+    return {};
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+};
+
+/**
+ * 电报列表（当日最新20条）
+ * @returns {Promise<Array<tools.NewsItem>>} 新闻列表
+ */
+export const telegraph = async (): Promise<Array<tools.NewsItem>> => {
+  try {
+    const url = `${CLS_API}/telegraph`;
+
+    const html = (await axios.get(url)).data;
+    const $ = cheerio.load(html);
+    const respStr = $("#__NEXT_DATA__").text();
+    const resp = JSON.parse(respStr);
+    const telegraphList: Telegram[] =
+      resp?.props?.initialState?.telegraph?.telegraphList || [];
+    const list: Array<tools.NewsItem> = telegraphList.map(
+      ({
+        brief,
+        content,
+        ctime,
+        share_img,
+        shareurl,
+        subjects,
+        title,
+        level,
+        id,
+      }) => {
+        const pubDate = dayjs.utc(ctime * 1000).tz("Asia/Shanghai");
+        const item: tools.NewsItem = {
+          id,
+          title: pubDate.format("HH:mm:ss") + " " + (title || brief),
+          url: shareurl,
+          // pubDate: ctime * 1000,
+          extra: {
+            brief,
+            content,
+            ctime,
+            share_img,
+            subjects: subjects || [],
+            level: level as unknown as string,
+          },
+        };
+        return item;
+      }
+    );
+
+    return list;
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+};
+
+/**
+ * 电报历史列表（按日期查询）
+ * !不包含level
+ * @returns {Promise<TelegramRes>} 新闻列表
+ */
+const telegraphHis = async () => {
+  try {
+    const params: Params = {
+      app: "CailianpressWeb",
+      os: "web",
+      sv: "8.4.6",
+      lastTime: dayjs().unix(), // 前5分钟的时间戳
+    };
+    params.sign = sign(params);
+    const body = {
+      app: "CailianpressWeb",
+      date: dayjs().format("YYYY-MM-DD"),
+      keyword: "",
+      os: "web",
+      page: 0,
+      rn: 30,
+      sv: "8.4.6",
+      type: "telegram",
+    };
+    const url = `${CLS_API}/api/sw`;
+
+    const { data: respData } = (
+      await axios({
+        method: "post",
+        url: url,
+        params: params,
+        data: body,
+      })
+    ).data;
+    const telegramList: Telegram[] = respData?.telegram?.data || [];
+    // TODO 暂时没用
+    return telegramList;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+// telegraph();

--- a/shared/init.ts
+++ b/shared/init.ts
@@ -26,6 +26,7 @@ import {weibo} from "./weibo";
 import {hotstock} from "./xueqiu";
 import {zaobao} from "./zaobao";
 import {zhihu} from "./zhihu";
+import {telegraph} from "./cls";
 
 // 自动注册所有 API
 export function initApis() {
@@ -64,4 +65,5 @@ export function initApis() {
     apiManager.registerApi("zhihu", zhihu)
 
     // 在这里添加其他 API 的注册
+    apiManager.registerApi("cls_telegraph", telegraph)
 }

--- a/types/cls.d.ts
+++ b/types/cls.d.ts
@@ -1,0 +1,145 @@
+export interface Telegram {
+  author_extends: AuthorExtends;
+  assocFastFact: null;
+  depth_extends: DepthExtends;
+  deny_comment: number;
+  level: Level;
+  reading_num: number;
+  content: string;
+  in_roll: number;
+  recommend: number;
+  confirmed: number;
+  jpush: number;
+  img: string;
+  user_id: number;
+  is_top: number;
+  brief: string;
+  id: number;
+  ctime: number;
+  type: number;
+  title: string;
+  bold: number;
+  sort_score: number;
+  comment_num: number;
+  modified_time: number;
+  status: number;
+  collection: number;
+  has_img: number;
+  category: string;
+  shareurl: string;
+  share_img: string;
+  share_num: number;
+  sub_titles: SubTitle[] | null;
+  tags: any[];
+  imgs: any[];
+  images: any[];
+  explain_num: number;
+  stock_list: List[];
+  is_ad: number;
+  ad: Ad;
+  subjects: Subject[] | null;
+  audio_url: string[] | null;
+  author: string;
+  plate_list: List[];
+  assocArticleUrl: string;
+  assocVideoTitle: string;
+  assocVideoUrl: string;
+  assocCreditRating: any[];
+  invest_calendar: InvestCalendar;
+  share_content: string;
+  gray_share: number;
+  comment_recommand: null;
+  timeline: null;
+}
+
+export interface Ad {
+  id: number;
+  title: string;
+  img: string;
+  url: string;
+  monitorUrl: string;
+  video_url: string;
+  adTag: string;
+  fullScreen: number;
+  type: number;
+}
+
+export enum AuthorExtends {
+  Empty = "",
+}
+
+export enum DepthExtends {
+  DepthExtends = "",
+  Empty = "[]",
+  Null = "null",
+}
+
+export interface InvestCalendar {
+  id: number;
+  data_id: number;
+  r_id: string;
+  type: number;
+  calendar_time: string;
+  setting_time: string;
+  event: null;
+  economic: null;
+  short_latents: null;
+}
+
+export enum Level {
+  A = "A",
+  B = "B",
+  C = "C",
+}
+
+export interface List {
+  rise_range_has_null: number | null;
+  RiseRange: number;
+  name: string;
+  StockID: string;
+  schema: string;
+  status: string;
+  last: number;
+  is_stib: boolean;
+}
+
+export interface SubTitle {
+  article_id: string;
+  name: string;
+  schema: string;
+  external_link: string;
+  img: string;
+  ctime: number;
+  author: string;
+  brief: string;
+  type: number;
+  reading_num: number;
+  level: string;
+  channel: Channel;
+}
+
+export enum Channel {
+  Cls = "cls",
+  ClsStib = "cls,stib",
+}
+
+export interface Subject {
+  article_id: number;
+  subject_id: number;
+  subject_name: string;
+  subject_img: string;
+  subject_description: string;
+  category_id: number;
+  attention_num: number;
+  is_attention: boolean;
+  is_reporter_subject: boolean;
+  plate_id: number;
+  channel: Channel;
+}
+
+export interface Params {
+  app: string;
+  os: string;
+  sv: string;
+  [key: string]: any;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,6 +28,7 @@ declare global {
         type WeiBoRes = import('shared').WeiBoRes;
         type StockRes = import('shared').StockRes;
         type ZhiHuRes = import('shared').ZhiHuRes;
+        type ClsTelegramRes = import('shared').ClsTelegramRes;
     }
 }
 

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -373,6 +373,17 @@ declare module 'shared' {
         }[]
     }
 
-
+    interface ClsTelegramRes {
+        title: string
+        url: string
+        brief: string
+        content: string
+        ctime: number
+        pubDate: string
+        share_img: string
+        subjects?: any[]
+        level: string
+        id: number
+    }
 }
 

--- a/types/tools.d.ts
+++ b/types/tools.d.ts
@@ -14,6 +14,7 @@ declare module 'tools' {
                 url: string
                 scale: number
             }
+            [key: string]: any // 其他属性,用于扩展
         }
     }
     export interface RSSInfo {


### PR DESCRIPTION
1、增加 财联社-电报接口（platform=cls_telegraph）
2、新增ts-md5、jssha加密库
3、修改tools.NewsItem类型，extra支持any，便于后续拓展内容
